### PR TITLE
Update urlEquals to address expected values

### DIFF
--- a/lib/api/assertions/urlEquals.js
+++ b/lib/api/assertions/urlEquals.js
@@ -18,10 +18,12 @@ exports.assertion = function(expected, msg) {
 
   this.message = msg || util.format('Testing if the URL equals "%s".', expected);
   this.expected = expected;
-
-  //custom code
-  if (typeof expected === "function") this.expected = expected();
-
+  
+  // Patch-1 to address if expected value is a function, then get the return value.
+  if (typeof expected === 'function') { 
+    this.expected = expected();
+  }
+  
   this.pass = function(value) {
     return value === this.expected;
   };


### PR DESCRIPTION
This patch addresses the issue if you pass a function as the parameter to the assertion. For more information, please refer to the ticket
 #452 assert.urlEquals fails test to validate urls
